### PR TITLE
Add sequence information to dataset metadata in SoccerNetGS

### DIFF
--- a/trackeval/datasets/soccernet_gs.py
+++ b/trackeval/datasets/soccernet_gs.py
@@ -421,6 +421,7 @@ class SoccerNetGS(_BaseDataset):
         data['num_tracker_ids'] = len(unique_tracker_ids)
         data['num_gt_ids'] = len(unique_gt_ids)
         data['num_timesteps'] = raw_data['num_timesteps']
+        data['seq'] = raw_data['seq']
 
         # Ensure that ids are unique per timestep.
         self._check_unique_ids(data)


### PR DESCRIPTION
The sequence name was not being added to the data dictionary, which led to a confusing error when checking unique_ids. Specifically, the code attempted to access [data["seq"]](https://github.com/SoccerNet/sn-trackeval/blob/main/trackeval/datasets/_base_dataset.py#L310), causing it to crash.

